### PR TITLE
fix the wait block issue

### DIFF
--- a/generator/plugins/neutron/neutron.go
+++ b/generator/plugins/neutron/neutron.go
@@ -208,7 +208,7 @@ func (s *NeutronServer) QueryStream(sql string) (rxgo.Observable, error) {
 	}
 
 	streamChannel := make(chan rxgo.Item)
-	resultStream := rxgo.FromChannel(streamChannel)
+	resultStream := rxgo.FromChannel(streamChannel, rxgo.WithPublishStrategy())
 
 	go func() {
 		defer close(streamChannel)

--- a/generator/samples/json/neutron.json
+++ b/generator/samples/json/neutron.json
@@ -1,5 +1,6 @@
 {
     "name": "test",
+    "timeout": 120,
     "source": {
         "batch_size": 1024,
         "concurency": 16,
@@ -29,5 +30,14 @@
                 "address": "http://localhost:8000"
             }
         }
-    ]
+    ],
+    "observer": {
+        "type": "neutron",
+        "properties": {
+            "address": "http://localhost:8000",
+            "query": "select * from test where value=9",
+            "time_column": "time",
+            "metric": "latency"
+        }
+    }
 }

--- a/generator/samples/yaml/kafka.yaml
+++ b/generator/samples/yaml/kafka.yaml
@@ -1,0 +1,22 @@
+---
+name: test
+source:
+  batch_size: 2048
+  concurency: 32
+  interval: 100
+  interval_delta: 0
+  fields:
+  - name: value
+    type: int
+    limit:
+    - 0
+    - 1000
+  - name: time
+    type: timestamp
+    timestamp_format: '2006-01-02 15:04:05.000000'
+  - name: timestamp
+    type: timestamp_int
+sinks:
+- type: kafka
+  properties:
+    brokers: localhost:9092

--- a/generator/samples/yaml/neutron.yaml
+++ b/generator/samples/yaml/neutron.yaml
@@ -1,0 +1,29 @@
+---
+name: test
+timeout: 120
+source:
+  batch_size: 512
+  concurency: 8
+  interval: 100
+  interval_delta: 0
+  batch_number: 100000000
+  fields:
+  - name: value
+    type: int
+    limit:
+    - 0
+    - 100
+  - name: time
+    type: timestamp
+    timestamp_format: '2006-01-02 15:04:05.000000'
+sinks:
+- type: neutron
+  properties:
+    address: http://localhost:8000
+observer:
+  type: neutron
+  properties:
+    address: http://localhost:8000
+    query: select * from test where value=9
+    time_column: time
+    metric: latency


### PR DESCRIPTION
this issue is because of when ingest and query running at the same time, when timeout happens, the ingest stopped first and query is blocked for waiting new events.

By using connected stream, this issue has been fixed.